### PR TITLE
Add more languages

### DIFF
--- a/nix-script.hs
+++ b/nix-script.hs
@@ -43,22 +43,19 @@ haskell = LangDef "haskell" d r i where
 
 python :: LangDef
 python = LangDef "python" d r i where
-  d pkgs = return $
-    Text.unwords (map ("pythonPackages." <>) pkgs)
+  d pkgs = "python" : map ("pythonPackages." <>) pkgs
   r script = ("python" , [script])
   i script = ("python" , ["-i", script])
 
 javascript :: LangDef
 javascript = LangDef "javascript" d r i where
-  d pkgs = return $
-    Text.unwords (map ("nodePackages." <>) pkgs)
+  d pkgs = "node" : map ("nodePackages." <>) pkgs
   r script = ("node" , [script])
   i script = ("node" , [])
 
 perl :: LangDef
 perl = LangDef "perl" d r i where
-  d pkgs = return $
-    Text.unwords (map ("perlPackages." <>) pkgs)
+  d pkgs = "perl" : map ("perlPackages." <>) pkgs
   r script = ("perl" , [script])
   i script = ("perl" , ["-d", script])
 

--- a/nix-script.hs
+++ b/nix-script.hs
@@ -25,14 +25,14 @@ import qualified Data.Text as Text
 
 -- | Information about a languages
 data LangDef = LangDef
-  { name :: String                        -- ^ Name of this language
+  { name :: String                         -- ^ Name of this language
   , deps :: [Text]   -> [Text]             -- ^ Convert langunage-specific dependencies to nix packages
   , run  :: FilePath -> (String, [String]) -- ^ Command to run the given file as script
   , repl :: FilePath -> (String, [String]) -- ^ Command to load the given file in an interpreter
   }
 
 languages :: [LangDef]
-languages = [haskell, shell]
+languages = [haskell, python, javascript, perl, shell]
 
 haskell :: LangDef
 haskell = LangDef "haskell" d r i where
@@ -40,6 +40,27 @@ haskell = LangDef "haskell" d r i where
     "haskellPackages.ghcWithPackages (hs: with hs; [" <> Text.unwords pkgs <> "])"
   r script = ("runhaskell" , [script])
   i script = ("ghci"       , [script])
+
+python :: LangDef
+python = LangDef "python" d r i where
+  d pkgs = return $
+    Text.unwords (map ("pythonPackages." <>) pkgs)
+  r script = ("python" , [script])
+  i script = ("python" , ["-i", script])
+
+javascript :: LangDef
+javascript = LangDef "javascript" d r i where
+  d pkgs = return $
+    Text.unwords (map ("nodePackages." <>) pkgs)
+  r script = ("node" , [script])
+  i script = ("node" , [])
+
+perl :: LangDef
+perl = LangDef "perl" d r i where
+  d pkgs = return $
+    Text.unwords (map ("perlPackages." <>) pkgs)
+  r script = ("perl" , [script])
+  i script = ("perl" , ["-d", script])
 
 shell :: LangDef
 shell = LangDef "shell" (extraPackages ++) r i where


### PR DESCRIPTION
I also tried adding a

``` haskell
passthrough :: String -> LangDef
passthrough name = LangDef name id r i where
  r script = (name, [script])
  i _      = (name, [])
```

to allow other languages and shells, like zsh in my case, but it fails with:

```
xargs: zsh: No such file or directory
```

Probably because I don't understand lense code. Can you help me?
