### PR TITLE
Consider merging my fork (lots of changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ To use `nix-script`, you need to add a header to your file. Here is an example f
 ```haskell
 #!/usr/bin/env nix-script
 #!> haskell
+#! env     | EDITOR
 #! haskell | text lens optparse-applicative
 #! shell   | nix nix-prefetch-scripts
 
@@ -39,6 +40,8 @@ main = {- ... -}
 The first line just tells the shell to use `nix-script` when executing the script. The next line is then read by `nix-script` to determine the language used for running the script. In this case, we tell `nix-script` that we want haskell, so it will use `runhaskell` to execute the script.
 
 The next lines the specify dependencies of the script. The first entry on each line is the language of the following dependencies. This is required so that language-specific names can be converted to the correct nix attribute names. You should have one line per language. In our case, we say that we want to use the `text`, `lens` and `optparse-applicative` haskell packages. We also want that `nix` and `nix-prefetch-scripts` are available in $PATH (the `shell` language doesn't apply any renaming to their dependencies and just passes them through unmodified).
+
+The lines starting with `env` specify additional environment variables to be kept in the environment where the script will run. In this case the variable`EDITOR` editor.
 
 We can now mark the script executable and run it:
 

--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@ pkgs.stdenv.mkDerivation {
   phases = [ "buildPhase" "installPhase" "fixupPhase" ];
   buildPhase = ''mkdir -p $out/bin; ghc -O2 $src -o $out/bin/nix-script -odir $TMP'';
   installPhase = ''ln -s $out/bin/nix-script $out/bin/nix-scripti'';
-  buildInputs = [ pkgs.haskellPackages.ghc ];
+  buildInputs = [ (pkgs.haskellPackages.ghcWithPackages (hs: with hs; [posix-escape])) ];
   meta = {
     homepage = https://github.com/bennofs/nix-script;
     description = "A shebang for running inside nix-shell.";

--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@ pkgs.stdenv.mkDerivation {
   phases = [ "buildPhase" "installPhase" "fixupPhase" ];
   buildPhase = ''mkdir -p $out/bin; ghc -O2 $src -o $out/bin/nix-script -odir $TMP'';
   installPhase = ''ln -s $out/bin/nix-script $out/bin/nix-scripti'';
-  buildInputs = [ (pkgs.haskellPackages.ghcWithPackages (hs: with hs; [lens text])) ];
+  buildInputs = [ pkgs.haskellPackages.ghc ];
   meta = {
     homepage = https://github.com/bennofs/nix-script;
     description = "A shebang for running inside nix-shell.";

--- a/example.hs
+++ b/example.hs
@@ -3,6 +3,8 @@
 #! haskell | text lens optparse-applicative
 #! shell | nix nix-prefetch-scripts
 
+import Control.Lens
+
 main :: IO ()
 main = do
   putStrLn "It works!"

--- a/example.sh
+++ b/example.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env nix-script
+#!>zsh
+#! nix | zsh
+
+function a { echo "this is zsh!" }
+a
+echo "your args: $@"

--- a/example.sh
+++ b/example.sh
@@ -4,4 +4,5 @@
 
 function a { echo "this is zsh!" }
 a
+echo $#
 echo "your args: $@"

--- a/nix-script.hs
+++ b/nix-script.hs
@@ -1,5 +1,5 @@
 -- | A shebang for running scripts inside nix-shell with defined dependencies
-module NixScript where
+module Main where
 
 import Control.Monad        (when)
 import Data.Maybe           (fromMaybe)
@@ -128,6 +128,7 @@ main = do
           (program, args) = interpreter language interactive file
 
       cmd <- makeCommand program args
+      putStrLn $ unwords ("--pure" : "--command" : cmd : "-p" : pkgs)
       callProcess "nix-shell" ("--pure" : "--command" : cmd : "-p" : pkgs)
 
     _ -> fail "missing or invalid header"

--- a/nix-script.hs
+++ b/nix-script.hs
@@ -33,7 +33,7 @@ basePackages = ["coreutils", "utillinux"]
 
 -- | Preserved environment variables
 baseEnv :: [String]
-baseEnv = ["LOCALE_ARCHIVE", "LANG", "TERMINFO", "TERM"]
+baseEnv = ["LOCALE_ARCHIVE", "SSL_CERT_FILE" ,"LANG", "TERMINFO", "TERM"]
 
 
 -- | List of supported language definitions

--- a/nix-script.hs
+++ b/nix-script.hs
@@ -8,9 +8,13 @@ import System.Environment           (lookupEnv, getProgName, getArgs)
 import System.Process               (callProcess)
 import System.Posix.Escape.Unicode  (escapeMany)
 
-
+-- | Enviroment variables
 type Env   = [String]
+
+-- | Program arguments
 type Args  = [String]
+
+-- | interpreter name and arguments
 type Inter = (String, Args)
 
 


### PR DESCRIPTION
I made a lot of changes and rewrote pretty much everything in `nix-script`
Here's a quick summary of what I did, I hope you like it.
## New features
### allow to specify additional environment

You can now add more environment variable to be preserved using `env` as in a language declaration.
For example:

``` shell
#! env | DISPLAY XDG_RUNTIME_DIR
```
### add passtrough for unknown languages

Instead of failing on a missing language definition nix-script now makes a new one on the fly taking the interpreter name and nix packages as is.
example:

``` shell
#!/usr/bin/env nix-script
#!>zsh
#! nix | zsh git haskellPackages.cabal-install
```
## Changes
### simplify the code

To make the code more readable and less complicated I
- completely dropped `lens` and `text` that were unnecessary in my opinion
- avoided the IO monad in pure computations: I think you did this way in order to use `fail` but since It was never caught anyway I simply used `error`
- replaced exceptions with maybes
### change how arguments are handled

I changed the way arguments are passed to the running script: Instead of having `xargs` load the args from the fd, I simply escaped the arguments with `posix-escape` and passed them along with the command to nix-shell.
### other changes
- I removed `git` and `hub` from the base packages since they are not really essentials
- I added `SSL_CERT_FILE` to the base environment which is needed by lots of programs that use SSL/TLS, like `curl` for example.
